### PR TITLE
Update README.md to account for misnamed method

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here's a quick guide to construct a simple application that retrieves messages u
 
   To do this, add a Podfile file similar to the one used in this repo's samples to the folder where your project (.xcodeproj file) is stored. Add these lines into your Podfile:
   ```Ruby
-  pod 'Office365', '~>0.5.0'
+  pod 'Office365', '~>0.5.4'
   pod 'ADALiOS', '~>1.0.0'
   ```
   
@@ -63,7 +63,7 @@ Here's a quick guide to construct a simple application that retrieves messages u
   Here's how to get all the messages for the current user.
 
   ```Objective-C
-  NSURLSessionTask* task = [[[client getMe] getMessages] execute:^(NSArray<MSOutlookMessage> *messages, NSError *error) {
+  NSURLSessionTask* task = [[[client getMe] getMessages] read:^(NSArray<MSOutlookMessage> *messages, NSError *error) {
     if(error == nil){
       dispatch_async(dispatch_get_main_queue(),
         ^{


### PR DESCRIPTION
In v0.5.4 onwards the function name for the `ODataCollectionFetcher` class is no longer `execute` but looks to be `read`

Please see [here](https://github.com/OfficeDev/Office-365-SDK-for-iOS/commit/d7574f9278d2ff15da3bf2a961d7a335de2caadc#diff-70ea766cc5ac2921b686c18348cc5161R95) for the difference.  

![screen shot 2014-11-05 at 5 57 30 am](https://cloud.githubusercontent.com/assets/839972/4918739/f138b5c8-64f3-11e4-94c3-f42165849be0.png)

This cause significant confusion for me since even the sample apps use execute and seem to work but I was having build failures when following the readme instructions
