### PR TITLE
Fix ADAuthenticationContext callback signature

### DIFF
--- a/sdk-objectivec/office365_odata_base/office365_odata_impl/ADALDependencyResolver.h
+++ b/sdk-objectivec/office365_odata_base/office365_odata_impl/ADALDependencyResolver.h
@@ -19,7 +19,7 @@
 -(void) acquireTokenSilentWithResource: (NSString*) resource
                               clientId: (NSString*) clientId
                            redirectUri: (NSURL*) redirectUri
-                       completionBlock: (id<ADAuthenticationResult>) completionBlock;
+                       completionBlock: (void(^)(id<ADAuthenticationResult>)) completionBlock;
 
 @end
 


### PR DESCRIPTION
After upgrading to latest version of xcode and ios 8.3, the project is failing with compilation error. It required to fix the completionblock signature.